### PR TITLE
Fix drop 2% battery

### DIFF
--- a/drivers/power/qpnp-fg.c
+++ b/drivers/power/qpnp-fg.c
@@ -5708,8 +5708,8 @@ static int fg_common_hw_init(struct fg_chip *chip)
 		}
 	}
 
-	rc = fg_mem_masked_write(chip, settings[FG_MEM_DELTA_SOC].address, 0xFF, 1,
-			settings[FG_MEM_DELTA_SOC].offset);
+	rc = fg_mem_masked_write(chip, settings[FG_MEM_DELTA_SOC].address, 0xFF,
+			settings[FG_MEM_DELTA_SOC].value == 1 ? 1 : soc_to_setpoint(settings[FG_MEM_DELTA_SOC].value),
 	if (rc) {
 		pr_err("failed to write delta soc rc=%d\n", rc);
 		return rc;


### PR DESCRIPTION
Back original code xiaomi. The code is broken on June 23 https://review.cyanogenmod.org/#/c/150593/1/drivers/power/qpnp-fg.c
